### PR TITLE
Extract Sheet and Shred classes away from their IO operations.

### DIFF
--- a/unshred/__init__.py
+++ b/unshred/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.0.8'
+__version__ = '0.0.9'
 
 try:
     from .split import Sheet

--- a/unshred/sheet.py
+++ b/unshred/sheet.py
@@ -33,7 +33,7 @@ class Sheet(object):
             orig_image: cv.Mat instance with the original sheet image.
             dpi: optional (x resolution, y resolution) tuple or None.
                 If set to None, will try to guess dpi.
-            save_iamge: A callback to save debug images with args (name, img)
+            save_image: A callback to save debug images with args (name, img)
         """
 
         self._shreds = None
@@ -44,7 +44,6 @@ class Sheet(object):
         self._fg_mask = None
         self._shreds = None
 
-        self.dpi = dpi
         if dpi is None:
             self.res_x, self.res_y = self._guess_dpi()
         else:
@@ -326,16 +325,16 @@ class Sheet(object):
         if tags_suggestions:
             print(name, tags_suggestions)
 
-        return Shred(**{
-            "features": base_features,
-            "contour": c,
-            "img_roi": img_roi,
-            "name": name,
-            "piece_fname": piece_fname,
-            "features_fname": features_fname,
-            "piece_in_context_fname": piece_in_context,
-            "simplified_contour": simplified_contour,
-            "sheet": sheet_name,
-            "tags_suggestions": tags_suggestions,
-        })
+        return Shred(
+            contour=c,
+            features=base_features,
+            features_fname=features_fname,
+            img_roi=img_roi,
+            name=name,
+            piece_fname=piece_fname,
+            piece_in_context_fname=piece_in_context,
+            sheet=sheet_name,
+            simplified_contour=simplified_contour,
+            tags_suggestions=tags_suggestions,
+        )
 

--- a/unshred/split.py
+++ b/unshred/split.py
@@ -58,8 +58,11 @@ class SheetIO(object):
             tags = exifread.process_file(f)
 
         if "Image XResolution" in tags and "Image YResolution" in tags:
-            return (parse_resolution(tags["Image XResolution"]),
-                    parse_resolution(tags["Image YResolution"]))
+            try:
+                return (parse_resolution(tags["Image XResolution"]),
+                        parse_resolution(tags["Image YResolution"]))
+            except ValueError:
+                return None
         return None
 
     def save_image(self, fname, img, format=None):


### PR DESCRIPTION
The change separates IO operations on sheets and shreds (loading/rendering) from actual CV operations by extracting Sheet into a separate class unaware of files, or directories.
This is intended to make it easier to introduce localised unittests for separate CV modules.
