### PR TITLE
Clarify the size features.

### DIFF
--- a/unshred/__init__.py
+++ b/unshred/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.0.9'
+__version__ = '0.1.0'
 
 try:
     from .split import Sheet

--- a/unshred/features/geometry.py
+++ b/unshred/features/geometry.py
@@ -15,18 +15,14 @@ class GeometryFeatures(AbstractShredFeature):
         # Also top and bottom points on the contour
         topmost = map(int, contour[contour[:, :, 1].argmin()][0])
         bottommost = map(int, contour[contour[:, :, 1].argmax()][0])
-        _, _, r_w, r_h = cv2.boundingRect(contour)
         tags = []
 
         if solidity < 0.75:
             tags.append("Suspicious shape")
 
-        width_mm = self.sheet.px_to_mm(r_w)
-        height_mm = self.sheet.px_to_mm(r_h)
+        width_mm = self.sheet.px_to_mm(shred.shape[0])
+        height_mm = self.sheet.px_to_mm(shred.shape[1])
         ratio = shred.shape[0] / float(shred.shape[1])
-
-        if width_mm > 6:
-            tags.append("Suspicious width")
 
         return {
             "area": area,

--- a/unshred/sheet.py
+++ b/unshred/sheet.py
@@ -342,11 +342,14 @@ class Sheet(object):
         features_fname = self.save_image("pieces/%s_mask" % name, mask, "png")
 
         base_features = {
-            "angle": angle,
-            "pos_x": r_x,
-            "pos_y": r_y,
-            "pos_width": r_w,
-            "pos_height": r_h
+            # On_sheet_* features describe the min counding box on the sheet.
+            "on_sheet_x": r_x,
+            "on_sheet_y": r_y,
+            "on_sheet_width": r_w,
+            "on_sheet_height": r_h,
+            "on_sheet_angle": angle,
+            "width": img_roi.shape[1],
+            "height": img_roi.shape[0],
         }
 
         tags_suggestions = []

--- a/unshred/split.py
+++ b/unshred/split.py
@@ -109,7 +109,7 @@ class SheetIO(object):
         shreds = self.get_shreds()
         for c in shreds:
             # Slight pre-processing of the features of each piece
-            c.features["angle"] = "%8.1f&deg;" % c.features["angle"]
+            c.features["on_sheet_angle"] = "%8.1f&deg;" % c.features["on_sheet_angle"]
             c.features["ratio"] = "%8.2f" % c.features["ratio"]
             c.features["solidity"] = "%8.2f" % c.features["solidity"]
 


### PR DESCRIPTION
Set height/width_mm to the size of the actual resulting shred (cropped, rotated), not to the size of the original straight shred bounding box within a sheet.